### PR TITLE
Extend to explicit dot operations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LazyBroadcast"
 uuid = "9dccce8e-a116-406d-9fcc-a88ed4f510c8"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [compat]
 julia = "^1.10"

--- a/src/LazyBroadcast.jl
+++ b/src/LazyBroadcast.jl
@@ -6,8 +6,31 @@ include("code_lowered_single_expression.jl")
 transform(x) = x
 transform(s::Symbol) = s
 # Expression: recursively transform for Expr
+const dot_ops = (
+    Symbol(".+"),
+    Symbol(".-"),
+    Symbol(".*"),
+    Symbol("./"),
+    Symbol(".="),
+    Symbol(".=="),
+    Symbol(".≠"),
+    Symbol(".^"),
+    Symbol(".!="),
+    Symbol(".>"),
+    Symbol(".<"),
+    Symbol(".>="),
+    Symbol(".<="),
+    Symbol(".≤"),
+    Symbol(".≥"),
+)
+isa_dot_op(op) = any(x -> op == x, dot_ops)
 function transform(e::Expr)
     if e.head == :macrocall && e.args[1] == Symbol("@__dot__")
+        se = code_lowered_single_expression(e)
+        margs = materialize_args(se)
+        subexpr = :($(margs[2]))
+        subexpr
+    elseif e.head == :call && isa_dot_op(e.args[1])
         se = code_lowered_single_expression(e)
         margs = materialize_args(se)
         subexpr = :($(margs[2]))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -16,7 +16,7 @@ function check_restrictions(expr)
         "Loops are not allowed inside"
     elseif expr.head == :if
         "If-statements are not allowed inside"
-    elseif expr.head == :call
+    elseif expr.head == :call && !(isa_dot_op(expr.args[1]))
         "Function calls are not allowed inside"
     elseif expr.head == :(=)
         "Non-broadcast assignments are not allowed inside"
@@ -35,6 +35,13 @@ function check_restrictions(expr)
             arg isa Symbol && continue
             check_restrictions(arg)
         end
+    elseif expr.head == :call && isa_dot_op(expr.args[1])
+        # Allows for LB.lazy_broadcasted(:(a .+ foo(b)))
+        # where foo(b) could be a getter to an array.
+        # This technically opens the door to incorrectness,
+        # as foo could change the pointer of `b` to something else
+        # however, this seems unlikely.
+    elseif expr.head == Symbol(".") # dot function call
     else
         @show dump(expr)
         @show dump(expr)

--- a/test/lazy_broadcasted.jl
+++ b/test/lazy_broadcasted.jl
@@ -1,13 +1,28 @@
+#=
+julia --project
+using Revise; include(joinpath("test", "lazy_broadcasted.jl"))
+=#
 using Test
 import LazyBroadcast as LB
 
 a = rand(3, 3)
 b = rand(3, 3)
 
-bce = LB.lazy_broadcasted(:(@. a + b))
-bco = LB.@lazy_broadcasted @. a + b
 
 @testset "lazy_broadcasted" begin
+    bce = LB.lazy_broadcasted(:(@. a + b))
+    bco = LB.@lazy_broadcasted @. a + b
     @test bce == :(Base.broadcasted(+, a, b))
     @test bco == Base.broadcasted(+, a, b)
+
+    bce = LB.lazy_broadcasted(:(a .+ b))
+    bco = LB.@lazy_broadcasted a .+ b
+    @test bce == :(Base.broadcasted(+, a, b))
+    @test bco == Base.broadcasted(+, a, b)
+
+    bce = LB.lazy_broadcasted(:(a .+ foo.(b)))
+    @test bce == :(Base.broadcasted(+, a, Base.broadcasted(foo, b)))
+
+    bce = LB.lazy_broadcasted(:(a .+ foo(b)))
+    @test bce == :(Base.broadcasted(+, a, foo(b)))
 end


### PR DESCRIPTION
This PR extends `@lazy_broadcast` to explicit dot operations.