### PR TITLE
Extend compat to include julia 1.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.9'
           - '1.10'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LazyBroadcast"
 uuid = "9dccce8e-a116-406d-9fcc-a88ed4f510c8"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.1.3"
+version = "0.1.4"
 
 [compat]
 julia = "1.9"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = ["CliMA Contributors <clima-software@caltech.edu>"]
 version = "0.1.3"
 
 [compat]
-julia = "^1.10"
+julia = "1.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
I am not sure if there's any specific reason to restrict to julia 1.10+, but, if possible, it would be nice to keep the lower bound to 1.9 because most of our packages are compatible with that version.

(Currently, LazyBroadcast.jl forces the ClimaCore test suite to require julia 1.10)